### PR TITLE
Add multiple tiles 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,8 @@ module.exports = {
     'no-use-before-define': [0, 'never'],
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
     'react/jsx-wrap-multilines': [0, 'never'],
+    // A nice idea, but doesn't seem to work with `{...props}: Props` pattern
+    'react/no-unused-prop-types': [0, 'never'],
     semi: ['error', 'never'],
   },
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "html-webpack-plugin": "^2.30.1",
     "immutability-helper": "^2.6.6",
     "jest": "^22.4.2",
+    "lodash": "^4.17.5",
     "postcss-cssnext": "^3.0.2",
     "postcss-discard-comments": "^2.0.4",
     "postcss-loader": "^2.0.10",

--- a/src/actions.js
+++ b/src/actions.js
@@ -5,6 +5,7 @@ import type {
   ActiveTileSetAction,
   Color,
   Tile,
+  TileClearedAction,
   TileCreatedAction,
   TileUpdatedAction,
 } from './types'
@@ -19,6 +20,11 @@ export const setActiveTile = (tileName: string): ActiveTileSetAction => ({
     name: tileName,
   },
   type: 'ACTIVE_TILE_SET',
+})
+
+export const clearTile = (name: string): TileClearedAction => ({
+  payload: { name },
+  type: 'TILE_CLEARED',
 })
 
 export const createTile = (tile: Tile): TileCreatedAction => ({

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,8 +1,26 @@
 // @flow
 
-import type { ActiveColorSetAction, Color } from './types'
+import type {
+  ActiveColorSetAction,
+  ActiveTileSetAction,
+  Color,
+  Tile,
+  TileCreatedAction,
+} from './types'
 
 export const setActiveColor = (color: Color): ActiveColorSetAction => ({
   payload: color,
   type: 'ACTIVE_COLOR_SET',
+})
+
+export const setActiveTile = (tileName: string): ActiveTileSetAction => ({
+  payload: {
+    name: tileName,
+  },
+  type: 'ACTIVE_TILE_SET',
+})
+
+export const createTile = (tile: Tile): TileCreatedAction => ({
+  payload: { tile },
+  type: 'TILE_CREATED',
 })

--- a/src/actions.js
+++ b/src/actions.js
@@ -6,6 +6,7 @@ import type {
   Color,
   Tile,
   TileCreatedAction,
+  TileUpdatedAction,
 } from './types'
 
 export const setActiveColor = (color: Color): ActiveColorSetAction => ({
@@ -23,4 +24,9 @@ export const setActiveTile = (tileName: string): ActiveTileSetAction => ({
 export const createTile = (tile: Tile): TileCreatedAction => ({
   payload: { tile },
   type: 'TILE_CREATED',
+})
+
+export const updateTile = (tile: Tile): TileUpdatedAction => ({
+  payload: { tile },
+  type: 'TILE_UPDATED',
 })

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,25 +1,59 @@
 // @flow
 import * as React from 'react'
+import { connect } from 'react-redux'
 
 import style from './app.css'
 import Canvas from './Canvas'
 import SelectPalette from './SelectPalette'
 import TilePanel from './TilePanel'
+import { clearTile } from '../actions'
+import { getActiveTile } from '../selectors'
+import type { AppState } from '../types'
 
-const App = () =>
-  <div className={style.app}>
-    <header className={style.header}>
-      <h1>GameBoy Z80 Tools</h1>
-    </header>
+type MappedProps = {
+  activeTileName: string,
+}
 
-    <div className={style.container}>
-      <TilePanel />
+type DispatchProps = {
+  clearTile: string => any,
+}
 
-      <div className={style.canvas}>
-        <SelectPalette />
-        <Canvas height={8} width={8} />
+type Props = DispatchProps & MappedProps
+
+const App = (props: Props) => {
+  const onClear = () => props.clearTile(props.activeTileName)
+
+  return (
+    <div className={style.app}>
+      <header className={style.header}>
+        <h1>GameBoy Z80 Tools</h1>
+      </header>
+
+      <div className={style.container}>
+        <TilePanel />
+
+        <div className={style.canvas}>
+          <div className={style.controls}>
+            <SelectPalette />
+            <div>
+              <button onClick={onClear} type="button">
+                Clear
+              </button>
+            </div>
+          </div>
+          <Canvas height={8} width={8} />
+        </div>
       </div>
     </div>
-  </div>
+  )
+}
 
-export default App
+const mapState = (state: AppState) => ({
+  activeTileName: (getActiveTile(state) || {}).name,
+})
+
+const mapDispatch = {
+  clearTile,
+}
+
+export default connect(mapState, mapDispatch)(App)

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,6 +4,7 @@ import * as React from 'react'
 import style from './app.css'
 import Canvas from './Canvas'
 import SelectPalette from './SelectPalette'
+import TilePanel from './TilePanel'
 
 const App = () =>
   <div className={style.app}>
@@ -12,8 +13,12 @@ const App = () =>
     </header>
 
     <div className={style.container}>
-      <SelectPalette />
-      <Canvas height={8} width={8} />
+      <TilePanel />
+
+      <div className={style.canvas}>
+        <SelectPalette />
+        <Canvas height={8} width={8} />
+      </div>
     </div>
   </div>
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux'
 
 import style from './app.css'
 import Canvas from './Canvas'
+import Panel from './Panel'
 import SelectPalette from './SelectPalette'
 import TilePanel from './TilePanel'
 import { clearTile } from '../actions'
@@ -30,19 +31,21 @@ const App = (props: Props) => {
       </header>
 
       <div className={style.container}>
-        <TilePanel />
-
-        <div className={style.canvas}>
-          <div className={style.controls}>
-            <SelectPalette />
-            <div>
-              <button onClick={onClear} type="button">
-                Clear
-              </button>
+        <Panel>
+          <div className={style.canvas}>
+            <div className={style.controls}>
+              <SelectPalette />
+              <div>
+                <button onClick={onClear} type="button">
+                  Clear
+                </button>
+              </div>
             </div>
+            <Canvas height={8} width={8} />
           </div>
-          <Canvas height={8} width={8} />
-        </div>
+        </Panel>
+
+        <TilePanel />
       </div>
     </div>
   )

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -5,6 +5,7 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 
 import style from './canvas.css'
+import PixelGrid from './PixelGrid'
 import { updateTile } from '../actions'
 import { getActiveTile } from '../selectors'
 import type {
@@ -13,13 +14,15 @@ import type {
   Coords,
   Palette,
   Pixel,
-  PixelGrid,
+  PixelGrid as PixelGridType,
   Tile,
 } from '../types'
 import * as pixelGrid from '../util/pixel-grid'
 import * as convert from '../util/convert'
 
+// $FlowFixMe
 const toColorGrid = (canvas: PixelGrid): Array<Array<number>> =>
+  // $FlowFixMe
   canvas.map(row => row.map(({ color }) => color))
 
 type OwnProps = {
@@ -72,55 +75,25 @@ class Canvas extends React.Component<Props, State> {
       .map(h => `${h}`)
       .join(' ')
 
-    const rows = []
-    for (let y = 0; y < height; y++) {
-      const pixels = []
-      for (let x = 0; x < width; x++) {
-        const pixel = activeTile.grid[y][x]
-        const pixelStyle = {
-          backgroundColor: activePalette[pixel.color],
-        }
-
-        const update = () => this.updatePixel({ x, y })
-
-        const onMouseEnter = () => {
-          if (this.state.isClicking) {
-            update()
-          }
-        }
-
-        pixels.push(
-          <td
-            className={style.pixel}
-            key={`${y}-${x}`}
-            onClick={update}
-            onMouseEnter={onMouseEnter}
-            style={pixelStyle}
-          />
-        )
-      }
-
-      rows.push(
-        <tr key={y}>
-          {pixels}
-        </tr>
-      )
-    }
-
     const onMouseDown = () => this.setState({ isClicking: true })
     const onMouseUp = () => this.setState({ isClicking: false })
+    const onMouseEnterPixel = (coords: Coords) => {
+      if (this.state.isClicking) {
+        this.updatePixel(coords)
+      }
+    }
 
     return (
       <div className={style.container}>
-        <table
+        <PixelGrid
           className={style.canvas}
+          grid={activeTile.grid}
+          onClickPixel={this.updatePixel}
           onMouseDown={onMouseDown}
+          onMouseEnterPixel={onMouseEnterPixel}
           onMouseUp={onMouseUp}
-        >
-          <tbody>
-            {rows}
-          </tbody>
-        </table>
+          palette={activePalette}
+        />
         <h3>
           {activeTile.name}
         </h3>

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -121,6 +121,9 @@ class Canvas extends React.Component<Props, State> {
             {rows}
           </tbody>
         </table>
+        <h3>
+          {activeTile.name}
+        </h3>
         <pre>
           {hex}
         </pre>

--- a/src/components/Canvas.js
+++ b/src/components/Canvas.js
@@ -43,7 +43,7 @@ class Canvas extends React.Component<Props, State> {
     ;(this: any).updatePixel = this.updatePixel.bind(this)
 
     const { height, width } = this.props
-    const canvas = pixelGrid.mkGrid({ height, width })
+    const canvas = pixelGrid.makeEmptyGrid({ height, width })
     this.state = {
       canvas,
       isClicking: false,

--- a/src/components/Panel.js
+++ b/src/components/Panel.js
@@ -1,0 +1,14 @@
+// @flow
+import * as React from 'react'
+import style from './panel.css'
+
+type Props = {
+  children: any,
+}
+
+const Panel = ({ children }: Props) =>
+  <div className={style.panel}>
+    {children}
+  </div>
+
+export default Panel

--- a/src/components/PixelGrid.js
+++ b/src/components/PixelGrid.js
@@ -1,31 +1,78 @@
 // @flow
 /* eslint-disable react/no-array-index-key */
-
+import cx from 'classnames'
 import * as React from 'react'
 
 import style from './pixelGrid.css'
-import type { Palette, PixelGrid as PixelGridType } from '../types'
+import type {
+  Coords,
+  Palette,
+  Pixel,
+  PixelGrid as PixelGridType,
+} from '../types'
 
 type Props = {
+  className?: string,
   grid: PixelGridType,
+  onClickPixel?: (c: Coords, p: Pixel) => any,
+  onMouseEnterPixel?: (c: Coords, p: Pixel) => any,
   palette: Palette,
 }
 
-const PixelGrid = ({ grid, palette }: Props) =>
-  <table className={style.grid}>
-    <tbody>
-      {grid.map((row, rowIdx) =>
-        <tr key={rowIdx}>
-          {row.map(({ color }, pixelIdx) =>
-            <td
-              className={style.pixel}
-              key={`${rowIdx}-${pixelIdx}`}
-              style={{ backgroundColor: palette[color] }}
-            />
-          )}
-        </tr>
-      )}
-    </tbody>
-  </table>
+const PixelGrid = ({
+  className,
+  grid,
+  onClickPixel,
+  onMouseEnterPixel,
+  palette,
+  ...props
+}: Props) => {
+  const rows = grid.map((row: Pixel[], y: number) => {
+    const pixels = row.map((pixel: Pixel, x: number) => {
+      const coords = { x, y }
+      const onClick = () => {
+        if (typeof onClickPixel === 'function') {
+          onClickPixel(coords, pixel)
+        }
+      }
+
+      const onMouseEnter = () => {
+        if (typeof onMouseEnterPixel === 'function') {
+          onMouseEnterPixel(coords, pixel)
+        }
+      }
+
+      return (
+        <td
+          className={style.pixel}
+          key={JSON.stringify(coords)}
+          onClick={onClick}
+          onMouseEnter={onMouseEnter}
+          style={{ backgroundColor: palette[pixel.color] }}
+        />
+      )
+    })
+
+    return (
+      <tr key={y}>
+        {pixels}
+      </tr>
+    )
+  })
+
+  return (
+    <table className={cx(style.grid, className)} {...props}>
+      <tbody>
+        {rows}
+      </tbody>
+    </table>
+  )
+}
+
+PixelGrid.defaultProps = {
+  className: '',
+  onClickPixel: () => {},
+  onMouseEnterPixel: () => {},
+}
 
 export default PixelGrid

--- a/src/components/PixelGrid.js
+++ b/src/components/PixelGrid.js
@@ -1,4 +1,6 @@
 // @flow
+/* eslint-disable react/no-array-index-key */
+
 import * as React from 'react'
 
 import style from './pixelGrid.css'
@@ -12,11 +14,12 @@ type Props = {
 const PixelGrid = ({ grid, palette }: Props) =>
   <table className={style.grid}>
     <tbody>
-      {grid.map(row =>
-        <tr>
-          {row.map(({ color }) =>
+      {grid.map((row, rowIdx) =>
+        <tr key={rowIdx}>
+          {row.map(({ color }, pixelIdx) =>
             <td
               className={style.pixel}
+              key={`${rowIdx}-${pixelIdx}`}
               style={{ backgroundColor: palette[color] }}
             />
           )}

--- a/src/components/PixelGrid.js
+++ b/src/components/PixelGrid.js
@@ -1,0 +1,28 @@
+// @flow
+import * as React from 'react'
+
+import style from './pixelGrid.css'
+import type { Palette, PixelGrid as PixelGridType } from '../types'
+
+type Props = {
+  grid: PixelGridType,
+  palette: Palette,
+}
+
+const PixelGrid = ({ grid, palette }: Props) =>
+  <table className={style.grid}>
+    <tbody>
+      {grid.map(row =>
+        <tr>
+          {row.map(({ color }) =>
+            <td
+              className={style.pixel}
+              style={{ backgroundColor: palette[color] }}
+            />
+          )}
+        </tr>
+      )}
+    </tbody>
+  </table>
+
+export default PixelGrid

--- a/src/components/TilePanel.js
+++ b/src/components/TilePanel.js
@@ -3,26 +3,51 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 
 import style from './tilePanel.css'
+import { createTile, setActiveTile } from '../actions'
 import type { AppState, Tile } from '../types'
+import { makeEmptyGrid } from '../util/pixel-grid'
 
 type MappedProps = {
   tiles: Tile[],
 }
 
-const TilePanel = ({ tiles }: MappedProps) =>
-  <div className={style.panel}>
-    <h2>Tiles</h2>
-    <ul>
-      {tiles.map(({ name }) =>
-        <li>
-          {name}
-        </li>
-      )}
-    </ul>
-  </div>
+type DispatchProps = {
+  createTile: (tile: Tile) => any,
+  setActiveTile: string => any,
+}
 
-const mapState = ({ tiles }: AppState): MappedProps => ({
+const TilePanel = ({ tiles, ...props }: DispatchProps & MappedProps) => {
+  console.log(props)
+  const onClickCreate = () =>
+    props.createTile({
+      grid: makeEmptyGrid({ height: 8, width: 8 }),
+      name: `tile-${tiles.length}`,
+    })
+
+  return (
+    <div className={style.panel}>
+      <h2>Tiles</h2>
+      <ul>
+        {tiles.map(({ name }) =>
+          <li key={name} onClick={() => props.setActiveTile(name)}>
+            {name}
+          </li>
+        )}
+      </ul>
+      <button onClick={onClickCreate} type="button">
+        + New Tile
+      </button>
+    </div>
+  )
+}
+const mapState = ({ activeTile, tiles }: AppState): MappedProps => ({
+  activeTile,
   tiles,
 })
 
-export default connect(mapState)(TilePanel)
+const mapDispatch: DispatchProps = {
+  createTile,
+  setActiveTile,
+}
+
+export default connect(mapState, mapDispatch)(TilePanel)

--- a/src/components/TilePanel.js
+++ b/src/components/TilePanel.js
@@ -26,16 +26,17 @@ const TilePanel = ({
   tiles,
   ...props
 }: DispatchProps & MappedProps) => {
-  const onClickCreate = () =>
-    props.createTile({
+  const onClickCreate = () => {
+    const createTileAction = props.createTile({
       grid: makeEmptyGrid({ height: 8, width: 8 }),
       name: `tile-${tiles.length}`,
     })
 
+    props.setActiveTile(createTileAction.payload.tile.name)
+  }
+
   const renderTile = ({ grid, name }: Tile) => {
-    console.log(name, activeTile, name === activeTile)
     const tileClass = cx({ [style.active]: name === activeTile })
-    console.log(name, activeTile, name === activeTile, tileClass)
     return (
       <li
         className={tileClass}

--- a/src/components/TilePanel.js
+++ b/src/components/TilePanel.js
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { connect } from 'react-redux'
 
 import style from './tilePanel.css'
+import Panel from './Panel'
 import PixelGrid from './PixelGrid'
 import { createTile, setActiveTile } from '../actions'
 import type { AppState, Palette, Tile } from '../types'
@@ -52,7 +53,7 @@ const TilePanel = ({
   }
 
   return (
-    <div className={style.panel}>
+    <Panel>
       <h2>Tiles</h2>
       <ul className={style.tileList}>
         {tiles.map(renderTile)}
@@ -60,7 +61,7 @@ const TilePanel = ({
       <button onClick={onClickCreate} type="button">
         + New Tile
       </button>
-    </div>
+    </Panel>
   )
 }
 const mapState = ({

--- a/src/components/TilePanel.js
+++ b/src/components/TilePanel.js
@@ -17,7 +17,6 @@ type DispatchProps = {
 }
 
 const TilePanel = ({ tiles, ...props }: DispatchProps & MappedProps) => {
-  console.log(props)
   const onClickCreate = () =>
     props.createTile({
       grid: makeEmptyGrid({ height: 8, width: 8 }),

--- a/src/components/TilePanel.js
+++ b/src/components/TilePanel.js
@@ -1,0 +1,28 @@
+// @flow
+import * as React from 'react'
+import { connect } from 'react-redux'
+
+import style from './tilePanel.css'
+import type { AppState, Tile } from '../types'
+
+type MappedProps = {
+  tiles: Tile[],
+}
+
+const TilePanel = ({ tiles }: MappedProps) =>
+  <div className={style.panel}>
+    <h2>Tiles</h2>
+    <ul>
+      {tiles.map(({ name }) =>
+        <li>
+          {name}
+        </li>
+      )}
+    </ul>
+  </div>
+
+const mapState = ({ tiles }: AppState): MappedProps => ({
+  tiles,
+})
+
+export default connect(mapState)(TilePanel)

--- a/src/components/TilePanel.js
+++ b/src/components/TilePanel.js
@@ -1,13 +1,17 @@
 // @flow
+import cx from 'classnames'
 import * as React from 'react'
 import { connect } from 'react-redux'
 
 import style from './tilePanel.css'
+import PixelGrid from './PixelGrid'
 import { createTile, setActiveTile } from '../actions'
-import type { AppState, Tile } from '../types'
+import type { AppState, Palette, Tile } from '../types'
 import { makeEmptyGrid } from '../util/pixel-grid'
 
 type MappedProps = {
+  activePalette: Palette,
+  activeTile: ?string,
   tiles: Tile[],
 }
 
@@ -16,22 +20,41 @@ type DispatchProps = {
   setActiveTile: string => any,
 }
 
-const TilePanel = ({ tiles, ...props }: DispatchProps & MappedProps) => {
+const TilePanel = ({
+  activePalette,
+  activeTile,
+  tiles,
+  ...props
+}: DispatchProps & MappedProps) => {
   const onClickCreate = () =>
     props.createTile({
       grid: makeEmptyGrid({ height: 8, width: 8 }),
       name: `tile-${tiles.length}`,
     })
 
+  const renderTile = ({ grid, name }: Tile) => {
+    console.log(name, activeTile, name === activeTile)
+    const tileClass = cx({ [style.active]: name === activeTile })
+    console.log(name, activeTile, name === activeTile, tileClass)
+    return (
+      <li
+        className={tileClass}
+        key={name}
+        onClick={() => props.setActiveTile(name)}
+      >
+        <div className={style.gridContainer}>
+          <PixelGrid grid={grid} palette={activePalette} />
+        </div>
+        {name}
+      </li>
+    )
+  }
+
   return (
     <div className={style.panel}>
       <h2>Tiles</h2>
-      <ul>
-        {tiles.map(({ name }) =>
-          <li key={name} onClick={() => props.setActiveTile(name)}>
-            {name}
-          </li>
-        )}
+      <ul className={style.tileList}>
+        {tiles.map(renderTile)}
       </ul>
       <button onClick={onClickCreate} type="button">
         + New Tile
@@ -39,7 +62,12 @@ const TilePanel = ({ tiles, ...props }: DispatchProps & MappedProps) => {
     </div>
   )
 }
-const mapState = ({ activeTile, tiles }: AppState): MappedProps => ({
+const mapState = ({
+  activePalette,
+  activeTile,
+  tiles,
+}: AppState): MappedProps => ({
+  activePalette,
   activeTile,
   tiles,
 })

--- a/src/components/app.css
+++ b/src/components/app.css
@@ -44,3 +44,9 @@ h1 {
   flex-direction: column;
   justify-content: center;
 }
+
+.controls {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/components/app.css
+++ b/src/components/app.css
@@ -32,5 +32,13 @@ h1 {
   align-items: center;
   display: flex;
   justify-content: center;
+  flex-direction: row;
+}
+
+.canvas {
+  align-items: center;
+  display: flex;
+  flex: 1 1 100%;
   flex-direction: column;
+  justify-content: center;
 }

--- a/src/components/app.css
+++ b/src/components/app.css
@@ -33,6 +33,8 @@ h1 {
   display: flex;
   justify-content: center;
   flex-direction: row;
+  margin: 0 auto;
+  max-width: 960px;
 }
 
 .canvas {

--- a/src/components/app.css
+++ b/src/components/app.css
@@ -29,7 +29,7 @@ h1 {
 }
 
 .container {
-  align-items: center;
+  align-items: flex-start;
   display: flex;
   justify-content: center;
   flex-direction: row;

--- a/src/components/panel.css
+++ b/src/components/panel.css
@@ -1,0 +1,5 @@
+.panel {
+  border: solid 1px black;
+  margin: 8px;
+  padding: 16px;
+}

--- a/src/components/pixelGrid.css
+++ b/src/components/pixelGrid.css
@@ -1,0 +1,8 @@
+.grid {
+  border-collapse: collapse;
+}
+
+.pixel {
+  height: 4px;
+  width: 4px;
+}

--- a/src/components/tilePanel.css
+++ b/src/components/tilePanel.css
@@ -1,4 +1,34 @@
 .panel {
   border: solid 1px black;
+  padding: 24px;
   width: 320px;
+}
+
+.tileList {
+  list-style-type: none;
+  margin: 0 0 16px 0;
+  padding: 0;
+}
+
+.tileList li {
+  align-items: center;
+  border: solid 1px transparent;
+  cursor: pointer;
+  display: flex;
+  justify-content: flex-start;
+  padding: 4px;
+
+  &:hover {
+    border-color: fuchsia;
+  }
+}
+
+.active {
+  color: fuchsia !important;
+}
+
+.gridContainer {
+  border: solid 1px black;
+  display: inline-block;
+  margin-right: 8px;
 }

--- a/src/components/tilePanel.css
+++ b/src/components/tilePanel.css
@@ -28,7 +28,7 @@
 }
 
 .gridContainer {
-  border: solid 1px black;
+  border: solid 1px #aaa;
   display: inline-block;
   margin-right: 8px;
 }

--- a/src/components/tilePanel.css
+++ b/src/components/tilePanel.css
@@ -1,12 +1,7 @@
-.panel {
-  border: solid 1px black;
-  padding: 24px;
-  width: 320px;
-}
-
 .tileList {
   list-style-type: none;
   margin: 0 0 16px 0;
+  width: 200px;
   padding: 0;
 }
 
@@ -17,6 +12,7 @@
   display: flex;
   justify-content: flex-start;
   padding: 4px;
+  white-space: nowrap;
 
   &:hover {
     border-color: fuchsia;

--- a/src/components/tilePanel.css
+++ b/src/components/tilePanel.css
@@ -32,3 +32,7 @@
   display: inline-block;
   margin-right: 8px;
 }
+
+.active .gridContainer {
+  border-color: fuchsia;
+}

--- a/src/components/tilePanel.css
+++ b/src/components/tilePanel.css
@@ -1,0 +1,3 @@
+.panel {
+  border: solid 1px black;
+}

--- a/src/components/tilePanel.css
+++ b/src/components/tilePanel.css
@@ -1,3 +1,4 @@
 .panel {
   border: solid 1px black;
+  width: 320px;
 }

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -6,6 +6,7 @@ import type {
   ActiveColorSetAction,
   ActiveTileSetAction,
   AppState,
+  TileClearedAction,
   TileCreatedAction,
   TileUpdatedAction,
 } from './types'
@@ -32,6 +33,8 @@ const rootReducer = (state: AppState = initialState, action: Action) => {
       return setActiveColor(state, action)
     case 'ACTIVE_TILE_SET':
       return setActiveTile(state, action)
+    case 'TILE_CLEARED':
+      return clearTile(state, action)
     case 'TILE_CREATED':
       return createTile(state, action)
     case 'TILE_UPDATED':
@@ -40,6 +43,21 @@ const rootReducer = (state: AppState = initialState, action: Action) => {
       return state
   }
 }
+
+const clearTile = (
+  state: AppState,
+  { payload: { name } }: TileClearedAction
+): AppState =>
+  // FIXME this is janky
+  updateTile(state, {
+    payload: {
+      tile: {
+        name,
+        grid: makeEmptyGrid({ height: 8, width: 8 }),
+      },
+    },
+    type: 'TILE_UPDATED',
+  })
 
 const createTile = (
   state: AppState,

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,18 +1,27 @@
 // @flow
 import update from 'immutability-helper'
 import { makeEmptyGrid } from './util/pixel-grid'
-import type { Action, ActiveColorSetAction, AppState } from './types'
+import type {
+  Action,
+  ActiveColorSetAction,
+  ActiveTileSetAction,
+  AppState,
+  TileCreatedAction,
+} from './types'
 
-const makeDefaultState = (): AppState => ({
-  activeColor: 3,
-  activePalette: ['#FFFFFF', '#999999', '#444444', '#000000'],
-  tiles: [
-    {
-      grid: makeEmptyGrid({ height: 8, width: 8 }),
-      name: 'tile-0',
-    },
-  ],
-})
+const makeDefaultState = (): AppState => {
+  const defaultTile = {
+    grid: makeEmptyGrid({ height: 8, width: 8 }),
+    name: 'tile-0',
+  }
+
+  return {
+    activeColor: 3,
+    activePalette: ['#FFFFFF', '#999999', '#444444', '#000000'],
+    activeTile: defaultTile.name,
+    tiles: [defaultTile],
+  }
+}
 
 const initialState = makeDefaultState()
 
@@ -20,14 +29,28 @@ const rootReducer = (state: AppState = initialState, action: Action) => {
   switch (action.type) {
     case 'ACTIVE_COLOR_SET':
       return setActiveColor(state, action)
+    case 'ACTIVE_TILE_SET':
+      return setActiveTile(state, action)
+    case 'TILE_CREATED':
+      return createTile(state, action)
     default:
       return state
   }
 }
 
+const createTile = (
+  state: AppState,
+  { payload: { tile } }: TileCreatedAction
+): AppState => update(state, { tiles: { $push: [tile] } })
+
 const setActiveColor = (
   state: AppState,
   { payload }: ActiveColorSetAction
 ): AppState => update(state, { activeColor: { $set: payload } })
+
+const setActiveTile = (
+  state: AppState,
+  { payload: { name } }: ActiveTileSetAction
+): AppState => update(state, { activeTile: { $set: name } })
 
 export default rootReducer

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,10 +1,17 @@
 // @flow
 import update from 'immutability-helper'
+import { makeEmptyGrid } from './util/pixel-grid'
 import type { Action, ActiveColorSetAction, AppState } from './types'
 
-const makeDefaultState = () => ({
+const makeDefaultState = (): AppState => ({
   activeColor: 3,
   activePalette: ['#FFFFFF', '#999999', '#444444', '#000000'],
+  tiles: [
+    {
+      grid: makeEmptyGrid({ height: 8, width: 8 }),
+      name: 'tile-0',
+    },
+  ],
 })
 
 const initialState = makeDefaultState()

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -7,6 +7,7 @@ import type {
   ActiveTileSetAction,
   AppState,
   TileCreatedAction,
+  TileUpdatedAction,
 } from './types'
 
 const makeDefaultState = (): AppState => {
@@ -33,6 +34,8 @@ const rootReducer = (state: AppState = initialState, action: Action) => {
       return setActiveTile(state, action)
     case 'TILE_CREATED':
       return createTile(state, action)
+    case 'TILE_UPDATED':
+      return updateTile(state, action)
     default:
       return state
   }
@@ -52,5 +55,23 @@ const setActiveTile = (
   state: AppState,
   { payload: { name } }: ActiveTileSetAction
 ): AppState => update(state, { activeTile: { $set: name } })
+
+const updateTile = (
+  state: AppState,
+  { payload: { tile } }: TileUpdatedAction
+): AppState => {
+  const tileIndex = state.tiles.findIndex(({ name }) => name === tile.name)
+
+  // no-nop
+  if (tileIndex < 0) {
+    return state
+  }
+
+  return update(state, {
+    tiles: {
+      [tileIndex]: { $set: tile },
+    },
+  })
+}
 
 export default rootReducer

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,0 +1,5 @@
+// @flow
+import type { AppState, Tile } from './types'
+
+export const getActiveTile = ({ activeTile, tiles }: AppState): ?Tile =>
+  tiles.find(({ name }) => name === activeTile)

--- a/src/types.js
+++ b/src/types.js
@@ -26,6 +26,13 @@ export type TileCreatedAction = {
   type: 'TILE_CREATED',
 }
 
+export type TileUpdatedAction = {
+  payload: {
+    tile: Tile,
+  },
+  type: 'TILE_UPDATED',
+}
+
 export type Action = ActiveColorSetAction
 
 /*

--- a/src/types.js
+++ b/src/types.js
@@ -19,6 +19,13 @@ export type ActiveTileSetAction = {
   type: 'ACTIVE_TILE_SET',
 }
 
+export type TileClearedAction = {
+  payload: {
+    name: string,
+  },
+  type: 'TILE_CLEARED',
+}
+
 export type TileCreatedAction = {
   payload: {
     tile: Tile,

--- a/src/types.js
+++ b/src/types.js
@@ -3,12 +3,27 @@
 export type AppState = {
   activeColor: Color,
   activePalette: Palette,
+  activeTile: string,
   tiles: Tile[],
 }
 
 export type ActiveColorSetAction = {
   payload: Color,
   type: 'ACTIVE_COLOR_SET',
+}
+
+export type ActiveTileSetAction = {
+  payload: {
+    name: string,
+  },
+  type: 'ACTIVE_TILE_SET',
+}
+
+export type TileCreatedAction = {
+  payload: {
+    tile: Tile,
+  },
+  type: 'TILE_CREATED',
 }
 
 export type Action = ActiveColorSetAction

--- a/src/types.js
+++ b/src/types.js
@@ -3,6 +3,7 @@
 export type AppState = {
   activeColor: Color,
   activePalette: Palette,
+  tiles: Tile[],
 }
 
 export type ActiveColorSetAction = {
@@ -37,3 +38,8 @@ export type Pixel = {
 }
 
 export type PixelGrid = Array<Array<Pixel>>
+
+export type Tile = {
+  grid: PixelGrid,
+  name: string,
+}

--- a/src/util/pixel-grid.js
+++ b/src/util/pixel-grid.js
@@ -5,7 +5,10 @@ export const mkPixel = () => ({
   color: 0,
 })
 
-export const mkGrid = (opts: { height: number, width: number }): PixelGrid => {
+export const makeEmptyGrid = (opts: {
+  height: number,
+  width: number,
+}): PixelGrid => {
   const grid = []
   for (let y = 0; y < opts.height; y++) {
     grid[y] = new Array(opts.width)


### PR DESCRIPTION
### Changes
- Adds support for multiple tiles, stored in the reducer
- Adds a "clear" button
- Adds re-usable PixelGrid & Panel components 

<img width="1392" alt="screenshot 2018-03-19 09 20 42" src="https://user-images.githubusercontent.com/855595/37597874-03f46388-2b57-11e8-8021-5a53e0f45172.png">
